### PR TITLE
fix /slim initialization in node

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The package produced by `wasm-bodge` provides the following subpath exports whic
 - [The Problem](#the-problem)
 - [How wasm-bodge Solves It](#how-wasm-bodge-solves-it)
   - [Subpath Exports](#subpath-exports)
+  - [Shared Web Target Architecture](#shared-web-target-architecture)
   - [Environment-Specific Strategies](#environment-specific-strategies)
   - [The `/slim` Escape Hatch](#the-slim-escape-hatch)
 - [Build Output](#build-output)
@@ -224,33 +225,75 @@ We can be more specific with "conditional exports":
 
 The module resolver picks the most specific match for the current environment. Which conditions are supported depends on the environment and is generally not well standardized or documented - that's why this approach is fragile and why we need an escape hatch.
 
+### Shared Web Target Architecture
+
+A key design decision in wasm-bodge is that every entry point ultimately re-exports
+from the same `wasm-bindgen --target web` output module. The web target generates a
+module-level `let wasm;` variable that all binding functions reference, and exports an
+`initSync(bytes)` function that populates it. Because ES modules are singletons, any
+code that imports from `wasm_bindgen/web/<lib name>.js` shares this `wasm` variable.
+
+This means that if the root export (`.`) initializes the wasm module, the slim export
+(`./slim`) automatically becomes functional too — they're both backed by the same
+underlying module. This is the property that makes it safe for library authors to
+import from `/slim` while their consumers import from the root.
+
+Each environment just differs in *how* it obtains the wasm bytes and calls `initSync`:
+
+| Environment | How wasm is loaded | Init mechanism |
+|---|---|---|
+| Node.js | `fs.readFileSync` from disk | `initSync(bytes)` |
+| Browser (no bundler) | Base64-encoded in JS | `initSync(bytes)` |
+| Bundler (Webpack, Vite) | Bundler's native `.wasm` import | `__wbg_set_wasm(exports)` shim |
+| Cloudflare Workers | Synchronous wasm module import | `initSync({ module })` |
+| Slim | User-provided | User calls `initSync` |
+
+For CJS, a shared `cjs/web-bindings.cjs` bundle (built by esbuild from the web target)
+serves the same role. Both `cjs/node.cjs` and `cjs/slim.cjs` `require()` this bundle,
+and Node's require cache ensures they share the same module instance.
+
 ### Environment-Specific Strategies
 
-`wasm-bodge` creates entrypoint scripts for each supported environment, then uses `esbuild` to bundle them with the appropriate `wasm-bindgen` output.
+`wasm-bodge` creates entrypoint scripts for each supported environment. Each entrypoint
+initializes wasm using whatever mechanism is available in that environment, then
+re-exports from the shared web target module.
 
 ---
 
 #### Node.js
 
-`wasm-bindgen --target nodejs` produces CommonJS modules. Attempting to import this in our entry point scripts will throw errors because our package uses `"type": "module"` which means Node will attempt to import any `.js` file as an ES Module. To solve this we rename the generated `.js` to `.cjs` so Node.js treats it correctly.
+The Node.js entrypoint reads the wasm binary from disk using `node:fs` and calls
+`initSync` on the web target.
 
 **ES Module Entrypoint** (`./dist/esm/node.js`):
 ```javascript
-export * from '../wasm_bindgen/nodejs/<lib name>.cjs';
+import { initSync } from '../wasm_bindgen/web/<lib name>.js';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+initSync(readFileSync(join(__dirname, '../wasm_bindgen/web/<lib name>_bg.wasm')));
+export * from '../wasm_bindgen/web/<lib name>.js';
 ```
 
 **CommonJS Entrypoint** (`./dist/cjs/node.cjs`):
 ```javascript
-module.exports = require('../wasm_bindgen/nodejs/<lib name>.cjs');
+const bindings = require('./web-bindings.cjs');
+const fs = require('fs');
+const path = require('path');
+bindings.initSync(fs.readFileSync(path.join(__dirname, '../wasm_bindgen/web/<lib name>_bg.wasm')));
+module.exports = bindings;
 ```
 
 ---
 
 #### Browsers (without bundler)
 
-Browsers don't support importing `.wasm` directly, and we don't know what URL the wasm will be served from. so we embed the wasm as base64 in the JS file.
+Browsers don't support importing `.wasm` directly, and we don't know what URL the wasm
+will be served from, so we embed the wasm as base64 in the JS file.
 
-We use `--target web` and add a build step that base64-encodes the `.wasm` file into `wasm-base64.js`.
+We use `--target web` and add a build step that base64-encodes the `.wasm` file into
+`wasm-base64.js`.
 
 **ES Module Entrypoint** (`./dist/esm/web.js`):
 ```javascript
@@ -268,12 +311,27 @@ Bundled from the ESM entrypoint using `esbuild --format=cjs`.
 
 #### Bundlers (Webpack, Vite, Rollup, etc.)
 
-Bundlers can use `--target bundler` directly since they handle `.wasm` imports.
+Bundlers can handle `.wasm` imports natively, so we use the bundler target's wasm
+loading mechanism. However, we still re-export from the web target so that bundler and
+slim share the same wasm state.
+
+The shim imports the raw wasm from the `--target bundler` output (which the bundler
+knows how to resolve), then injects the resulting wasm exports into the web target's
+bindings via a post-processed `__wbg_set_wasm` export.
 
 **ES Module Entrypoint** (`./dist/esm/bundler.js`):
 ```javascript
-export * from '../wasm_bindgen/bundler/<lib name>.js';
+import { __wbg_set_wasm as __bundler_set_wasm } from '../wasm_bindgen/bundler/<lib name>_bg.js';
+import * as wasmExports from '../wasm_bindgen/bundler/<lib name>_bg.wasm';
+import { __wbg_set_wasm } from '../wasm_bindgen/web/<lib name>.js';
+__bundler_set_wasm(wasmExports);
+wasmExports.__wbindgen_start();
+__wbg_set_wasm(wasmExports);
+export * from '../wasm_bindgen/web/<lib name>.js';
 ```
+
+The bundler target's `__wbg_set_wasm` must be called first because `__wbindgen_start()`
+invokes wasm imports that reference the bundler target's internal `wasm` variable.
 
 **CommonJS Entrypoint** (`./dist/cjs/bundler.cjs`):
 Falls back to the base64 web entrypoint since CommonJS can't import `.wasm` directly.
@@ -282,7 +340,8 @@ Falls back to the base64 web entrypoint since CommonJS can't import `.wasm` dire
 
 #### Cloudflare Workers (workerd)
 
-Cloudflare Workers allow synchronous `.wasm` imports but still need JS wrapper initialization.
+Cloudflare Workers allow synchronous `.wasm` imports but still need JS wrapper
+initialization.
 
 **ES Module Entrypoint** (`./dist/esm/workerd.js`):
 ```javascript
@@ -318,7 +377,8 @@ Usage:
 
 ### The `/slim` Escape Hatch
 
-Despite our best efforts, some environments won't work with automatic detection. The `/slim` export provides manual initialization:
+Despite our best efforts, some environments won't work with automatic detection. The
+`/slim` export provides manual initialization:
 
 ```javascript
 import { initSync, myFunction } from "my-wasm-lib/slim";
@@ -329,7 +389,13 @@ initSync(bytes);
 myFunction();
 ```
 
-**This is crucial for library authors.** If you're writing a library that depends on a wasm-bodge package, always use the `/slim` export. This lets the application developer control WebAssembly initialization.
+**This is important for library authors.** If you're writing a library that depends on a
+wasm-bodge package, import from `/slim`. This avoids bundling a wasm initialization
+strategy that may not work in your consumer's environment.
+
+Because all entry points share the same underlying web target module, a consuming
+application can import from the root export (which auto-initializes) and your library's
+`/slim` import will automatically become functional — no coordination needed.
 
 **ES Module Entrypoint** (`./dist/esm/slim.js`):
 ```javascript
@@ -337,7 +403,12 @@ export * from '../wasm_bindgen/web/<lib name>.js';
 export { default } from '../wasm_bindgen/web/<lib name>.js';
 ```
 
-The `web` target doesn't auto-initialize and exports `initSync` for manual initialization.
+**CommonJS Entrypoint** (`./dist/cjs/slim.cjs`):
+```javascript
+module.exports = require('./web-bindings.cjs');
+```
+
+The web target doesn't auto-initialize and exports `initSync` for manual initialization.
 
 ---
 
@@ -348,25 +419,24 @@ The `web` target doesn't auto-initialize and exports `initSync` for manual initi
 ```
 dist/
     esm/
-        node.js           # Node.js ESM
-        web.js            # Browser (base64 embedded)
-        bundler.js        # Bundler entry
-        workerd.js        # Cloudflare Workers
-        slim.js           # Manual initialization
+        node.js           # Node.js ESM (fs.readFileSync + initSync)
+        web.js            # Browser (base64 embedded + initSync)
+        bundler.js        # Bundler shim (__wbg_set_wasm)
+        workerd.js        # Cloudflare Workers (sync wasm import)
+        slim.js           # Manual initialization (re-export only)
         wasm-base64.js    # Base64-encoded wasm
     cjs/
         node.cjs          # Node.js CommonJS
-        web.cjs           # Browser CommonJS
-        bundler.cjs       # Bundler CommonJS
-        workerd.cjs       # Cloudflare CommonJS
+        web.cjs           # Browser CommonJS (bundled from ESM)
         slim.cjs          # Manual init CommonJS
+        web-bindings.cjs  # Shared web target bundle (used by node.cjs + slim.cjs)
         wasm-base64.cjs   # Base64 CommonJS
     iife/
         index.js          # IIFE bundle for <script> tags
     wasm_bindgen/
-        nodejs/           # wasm-bindgen --target nodejs
-        web/              # wasm-bindgen --target web
-        bundler/          # wasm-bindgen --target bundler
+        nodejs/           # wasm-bindgen --target nodejs (used for .d.ts)
+        web/              # wasm-bindgen --target web (shared by all entry points)
+        bundler/          # wasm-bindgen --target bundler (wasm loading only)
     index.d.ts            # TypeScript declarations
     <package-name>.wasm   # Raw wasm file
 ```
@@ -414,7 +484,8 @@ The `package.json` exports are configured as:
 
 ### WebAssembly Initialization
 
-Why does `wasm-bindgen` have different targets? They all handle WebAssembly initialization differently.
+Why does `wasm-bindgen` have different targets? They all handle WebAssembly initialization
+differently.
 
 The standard WebAssembly API is imperative:
 
@@ -423,23 +494,25 @@ const wasmBytes = await fetch("my_module.wasm").then(res => res.arrayBuffer());
 const wasmModule = await WebAssembly.instantiate(wasmBytes, importObject);
 ```
 
-We want users to import our library like any other JS module, so we need to hide this initialization. Here's what `--target nodejs` generates:
+We want users to import our library like any other JS module, so we need to hide this
+initialization. The `--target web` output from wasm-bindgen generates binding functions
+that reference a module-level `let wasm;` variable, and exports an `initSync(bytes)`
+function that compiles and instantiates the wasm module, populating that variable.
 
-```javascript
-function add(left, right) {
-    const ret = wasm.add(left, right);
-    return ret >>> 0;
-}
-exports.add = add;
+wasm-bodge exploits the fact that ES modules are singletons: if two entry points both
+import from the same `wasm_bindgen/web/<lib name>.js` file, they share the same `wasm`
+variable. Each environment-specific entry point just needs to obtain the wasm bytes
+through whatever mechanism is available (filesystem read, base64 decode, bundler import,
+etc.) and call `initSync`. Once any entry point has initialized, all other entry points
+that import from the same web target module are also functional.
 
-const wasmPath = `${__dirname}/my_rust_crate_bg.wasm`;
-const wasmBytes = require('fs').readFileSync(wasmPath);
-const wasmModule = new WebAssembly.Module(wasmBytes);
-const wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports()).exports;
-wasm.__wbindgen_start();
-```
-
-This uses `require('fs').readFileSync(...)` which only works in Node.js CommonJS context - not in Deno, browsers, or Node.js ESM.
+The bundler environment is a special case. Bundlers handle `.wasm` imports natively via
+the `--target bundler` output, which uses `import * as wasm from './<lib>_bg.wasm'`.
+Rather than duplicating the wasm instantiation logic, the bundler shim lets the bundler
+load the wasm through its normal mechanism, then injects the resulting exports into the
+web target's bindings via `__wbg_set_wasm` (a function we add to the web target during
+post-processing). This way the bundler handles wasm loading optimally while still sharing
+state with `/slim`.
 
 ### Fixing Vite's Asset Preprocessor
 

--- a/src/build/entrypoints.rs
+++ b/src/build/entrypoints.rs
@@ -42,6 +42,7 @@ pub fn generate(out_dir: &Path, crate_name: &str) -> Result<()> {
 
 fn bundle_with_esbuild(out_dir: &Path, crate_name: &str) -> Result<()> {
     let esbuild = find_esbuild()?;
+    let wasm_name = crate_name.replace('-', "_");
 
     // Bundle IIFE from web entrypoint
     let esm_web = out_dir.join(targets::paths::esm_entrypoint(Environment::Web));
@@ -49,6 +50,14 @@ fn bundle_with_esbuild(out_dir: &Path, crate_name: &str) -> Result<()> {
     let global_name = crate_name.to_pascal_case();
 
     run_esbuild(&esbuild, &esm_web, &iife_output, "iife", Some(&global_name))?;
+
+    // Bundle shared CJS web bindings (used by both cjs/node.cjs and cjs/slim.cjs)
+    let web_js = out_dir.join(targets::paths::wasm_bindgen_js(
+        targets::WasmBindgenTarget::Web,
+        &wasm_name,
+    ));
+    let web_bindings_cjs = out_dir.join(targets::paths::cjs_web_bindings());
+    run_esbuild(&esbuild, &web_js, &web_bindings_cjs, "cjs", None)?;
 
     // Bundle CJS versions for environments that need it
     for env in Environment::all() {

--- a/src/build/post_process.rs
+++ b/src/build/post_process.rs
@@ -27,7 +27,11 @@ pub fn run(wasm_bindgen_dir: &Path, out_dir: &Path, crate_name: &str) -> Result<
     println!("  Applying @vite-ignore fix...");
     apply_vite_fix(&web_dir, &wasm_name)?;
 
-    // 3. Generate base64 wasm module
+    // 3. Add __wbg_set_wasm export to web target (enables bundler shim to inject wasm)
+    println!("  Adding __wbg_set_wasm export to web target...");
+    add_set_wasm_export(&web_dir, &wasm_name)?;
+
+    // 4. Generate base64 wasm module
     println!("  Generating base64 wasm module...");
     generate_base64_module(&web_dir, out_dir, &wasm_name)?;
 
@@ -52,6 +56,17 @@ fn apply_vite_fix(web_dir: &Path, wasm_name: &str) -> Result<()> {
 
     std::fs::write(&js_file, new_content.as_ref()).context("Failed to write modified JS file")?;
 
+    Ok(())
+}
+
+fn add_set_wasm_export(web_dir: &Path, wasm_name: &str) -> Result<()> {
+    let js_file = web_dir.join(format!("{}.js", wasm_name));
+    let mut content =
+        std::fs::read_to_string(&js_file).context("Failed to read wasm-bindgen web JS file")?;
+
+    content.push_str("\nexport function __wbg_set_wasm(val) { wasm = val; }\n");
+
+    std::fs::write(&js_file, &content).context("Failed to write modified web JS file")?;
     Ok(())
 }
 

--- a/src/build/targets.rs
+++ b/src/build/targets.rs
@@ -51,14 +51,14 @@ impl fmt::Display for WasmBindgenTarget {
 /// How an entrypoint initializes the wasm module.
 #[derive(Debug, Clone, Copy)]
 pub enum InitStrategy {
-    /// Auto-initializes via the wasm-bindgen output (nodejs target)
-    AutoNodejs,
+    /// Auto-initializes by reading wasm from disk via node:fs and calling initSync
+    NodeFsSync,
     /// Auto-initializes by embedding wasm as base64
     Base64Embedded,
     /// Auto-initializes via synchronous wasm import (workerd)
     SyncWasmImport,
-    /// Re-exports bundler target (bundler handles wasm loading)
-    BundlerPassthrough,
+    /// Imports wasm via bundler target, injects into web target bindings
+    BundlerShim,
     /// No initialization - user must call initSync manually
     Manual,
 }
@@ -107,11 +107,12 @@ impl Environment {
     }
 
     /// Which wasm-bindgen target this environment's entrypoint uses
+    #[cfg(test)]
     pub fn wasm_bindgen_target(&self) -> WasmBindgenTarget {
         match self {
-            Self::Node => WasmBindgenTarget::Nodejs,
+            Self::Node => WasmBindgenTarget::Web,
             Self::Web => WasmBindgenTarget::Web,
-            Self::Bundler => WasmBindgenTarget::Bundler,
+            Self::Bundler => WasmBindgenTarget::Web,
             Self::Workerd => WasmBindgenTarget::Web,
             Self::Iife => WasmBindgenTarget::Web, // bundled from web.js
             Self::Slim => WasmBindgenTarget::Web,
@@ -121,9 +122,9 @@ impl Environment {
     /// How this environment initializes the wasm module
     pub fn init_strategy(&self) -> InitStrategy {
         match self {
-            Self::Node => InitStrategy::AutoNodejs,
+            Self::Node => InitStrategy::NodeFsSync,
             Self::Web => InitStrategy::Base64Embedded,
-            Self::Bundler => InitStrategy::BundlerPassthrough,
+            Self::Bundler => InitStrategy::BundlerShim,
             Self::Workerd => InitStrategy::SyncWasmImport,
             Self::Iife => InitStrategy::Base64Embedded,
             Self::Slim => InitStrategy::Manual,
@@ -136,10 +137,10 @@ impl Environment {
     /// (specified in ROOT_EXPORT_MAPPING), so they don't need their own bundle.
     pub fn needs_cjs_bundle(&self) -> bool {
         match self {
-            // Node can directly require the .cjs file
-            Self::Node => false,
-            // Web and Slim use web target (ESM) so need bundling for CJS
-            Self::Web | Self::Slim => true,
+            // Node and Slim generate CJS directly (not bundled)
+            Self::Node | Self::Slim => false,
+            // Web uses web target (ESM) so needs bundling for CJS
+            Self::Web => true,
             // Bundler CJS falls back to web.cjs (doesn't need its own bundle)
             Self::Bundler => false,
             // Workerd CJS falls back to web.cjs (specified in ROOT_EXPORT_MAPPING)
@@ -271,6 +272,11 @@ pub mod paths {
         PathBuf::from("cjs/wasm-base64.cjs")
     }
 
+    /// Path to shared CJS web bindings bundle: cjs/web-bindings.cjs
+    pub fn cjs_web_bindings() -> PathBuf {
+        PathBuf::from("cjs/web-bindings.cjs")
+    }
+
     /// Path to TypeScript declarations: index.d.ts
     pub fn types() -> PathBuf {
         PathBuf::from("index.d.ts")
@@ -288,13 +294,20 @@ pub mod paths {
 
 /// Generates the JavaScript content for an ESM entrypoint.
 pub fn generate_esm_entrypoint(env: Environment, wasm_name: &str) -> String {
-    let target = env.wasm_bindgen_target();
-
     match env.init_strategy() {
-        InitStrategy::AutoNodejs => {
-            // Re-export from nodejs target (which auto-initializes)
-            let path = paths::wasm_bindgen_js(target, wasm_name);
-            format!("export * from '../{}';\n", path.display())
+        InitStrategy::NodeFsSync => {
+            // Read wasm from disk and initialize synchronously
+            format!(
+                r#"import {{ initSync }} from '../wasm_bindgen/web/{name}.js';
+import {{ readFileSync }} from 'node:fs';
+import {{ fileURLToPath }} from 'node:url';
+import {{ dirname, join }} from 'node:path';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+initSync(readFileSync(join(__dirname, '../wasm_bindgen/web/{name}_bg.wasm')));
+export * from '../wasm_bindgen/web/{name}.js';
+"#,
+                name = wasm_name
+            )
         }
         InitStrategy::Base64Embedded => {
             // Import base64, decode, init, then re-export
@@ -320,10 +333,22 @@ export * from '../wasm_bindgen/web/{name}.js';
                 name = wasm_name
             )
         }
-        InitStrategy::BundlerPassthrough => {
-            // Just re-export from bundler target
-            let path = paths::wasm_bindgen_js(target, wasm_name);
-            format!("export * from '../{}';\n", path.display())
+        InitStrategy::BundlerShim => {
+            // Import wasm via bundler target (bundler handles loading), inject
+            // into web target bindings so bundler and slim share wasm state.
+            // Must set wasm on the bundler target first because __wbindgen_start
+            // calls imports that reference the bundler target's wasm variable.
+            format!(
+                r#"import {{ __wbg_set_wasm as __bundler_set_wasm }} from '../wasm_bindgen/bundler/{name}_bg.js';
+import * as wasmExports from '../wasm_bindgen/bundler/{name}_bg.wasm';
+import {{ __wbg_set_wasm }} from '../wasm_bindgen/web/{name}.js';
+__bundler_set_wasm(wasmExports);
+wasmExports.__wbindgen_start();
+__wbg_set_wasm(wasmExports);
+export * from '../wasm_bindgen/web/{name}.js';
+"#,
+                name = wasm_name
+            )
         }
         InitStrategy::Manual => {
             // Re-export without initialization (user calls initSync)
@@ -337,15 +362,24 @@ export * from '../wasm_bindgen/web/{name}.js';
 
 /// Generates the JavaScript content for a CJS entrypoint (if not bundled).
 pub fn generate_cjs_entrypoint(env: Environment, wasm_name: &str) -> Option<String> {
-    // Only Node has a simple CJS entrypoint; others are bundled from ESM
-    if env == Environment::Node {
-        let path = paths::wasm_bindgen_js(WasmBindgenTarget::Nodejs, wasm_name);
-        Some(format!(
-            "module.exports = require('../{}');\n",
-            path.display()
-        ))
-    } else {
-        None
+    match env {
+        Environment::Node => {
+            // Load shared web bindings, read wasm from disk, initialize
+            Some(format!(
+                r#"const bindings = require('./web-bindings.cjs');
+const fs = require('fs');
+const path = require('path');
+bindings.initSync(fs.readFileSync(path.join(__dirname, '../wasm_bindgen/web/{name}_bg.wasm')));
+module.exports = bindings;
+"#,
+                name = wasm_name
+            ))
+        }
+        Environment::Slim => {
+            // Just re-export the shared web bindings (no initialization)
+            Some("module.exports = require('./web-bindings.cjs');\n".to_string())
+        }
+        _ => None,
     }
 }
 
@@ -367,22 +401,13 @@ mod tests {
         // Browser uses Web environment for CJS (fallback)
         assert_eq!(mapping.cjs, Environment::Web);
 
-        // Bundler environment uses the bundler wasm-bindgen target
-        assert_eq!(
-            mapping.esm.wasm_bindgen_target(),
-            WasmBindgenTarget::Bundler
-        );
+        // Bundler environment uses web target (shares wasm state with slim)
+        assert_eq!(mapping.esm.wasm_bindgen_target(), WasmBindgenTarget::Web);
 
         // The ESM entrypoint path
         assert_eq!(
             paths::esm_entrypoint(mapping.esm),
             PathBuf::from("esm/bundler.js")
-        );
-
-        // Which re-exports from
-        assert_eq!(
-            paths::wasm_bindgen_js(WasmBindgenTarget::Bundler, "my_lib"),
-            PathBuf::from("wasm_bindgen/bundler/my_lib.js")
         );
     }
 

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -614,6 +614,16 @@ fn test_workerd_slim() {
 }
 
 #[test]
+fn test_node_esm_cross_init() {
+    run_test("node_esm_cross_init").unwrap();
+}
+
+#[test]
+fn test_node_cjs_cross_init() {
+    run_test("node_cjs_cross_init").unwrap();
+}
+
+#[test]
 fn test_iife_script() {
     run_test("iife_script").unwrap();
 }

--- a/tests/templates/node_cjs_cross_init/package.json
+++ b/tests/templates/node_cjs_cross_init/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "node-cjs-cross-init-test",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "build": "true",
+    "test": "node test.cjs"
+  }
+}

--- a/tests/templates/node_cjs_cross_init/test.cjs
+++ b/tests/templates/node_cjs_cross_init/test.cjs
@@ -1,0 +1,20 @@
+// Test that requiring the root export auto-initializes wasm for slim too.
+// Both cjs/node.cjs and cjs/slim.cjs require the same cjs/web-bindings.cjs,
+// and Node's require cache ensures they share state.
+
+const { add } = require('test-wasm-lib');
+const { greet } = require('test-wasm-lib/slim');
+
+// add comes from root (auto-initialized)
+const sum = add(2, 3);
+if (sum !== 5) {
+  throw new Error(`Expected add(2, 3) = 5, got ${sum}`);
+}
+
+// greet comes from slim (should work without manual init)
+const greeting = greet('World');
+if (greeting !== 'Hello, World!') {
+  throw new Error(`Expected greet('World') = 'Hello, World!', got ${greeting}`);
+}
+
+console.log('WASM_BODGE_TEST_PASSED');

--- a/tests/templates/node_esm_cross_init/package.json
+++ b/tests/templates/node_esm_cross_init/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "node-esm-cross-init-test",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "true",
+    "test": "node test.mjs"
+  }
+}

--- a/tests/templates/node_esm_cross_init/test.mjs
+++ b/tests/templates/node_esm_cross_init/test.mjs
@@ -1,0 +1,21 @@
+// Test that importing the root export auto-initializes wasm for slim too.
+// The root export initializes via initSync, and since both root and slim
+// import from the same underlying web target module, the slim export should
+// also be functional without manual initialization.
+
+import { add } from 'test-wasm-lib';
+import { greet } from 'test-wasm-lib/slim';
+
+// add comes from root (auto-initialized)
+const sum = add(2, 3);
+if (sum !== 5) {
+  throw new Error(`Expected add(2, 3) = 5, got ${sum}`);
+}
+
+// greet comes from slim (should work without manual init)
+const greeting = greet('World');
+if (greeting !== 'Hello, World!') {
+  throw new Error(`Expected greet('World') = 'Hello, World!', got ${greeting}`);
+}
+
+console.log('WASM_BODGE_TEST_PASSED');


### PR DESCRIPTION
Problem: when importing a package using the `/slim` export in Node, then later using the `.` export, the imports which referenced the `/slim` export would never get their WebAssembly initialized. This is because the `/slim` export in Node points at a different webassembly bindings module than the `.` export.

Solution: modify all the entry points so that everything points at the same underlying bindings module (the `web` target). This way regardless of which entry point performs initialization, the `/slim` export will be initialized.

Fixes #1 