### PR TITLE
Add `/debug/*` variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## Unreleased
+
+### Added
+
+* A `/debug/slim` subpath export is now emitted alongside the other `/debug`
+  exports when `--debug-variant` is set. This lets consumers who use `/slim`
+  for manual initialization switch to `/debug/slim` while debugging without
+  otherwise changing their code.
+
+### Fixed
+
+* Manually initializing the debug wasm now works. Use `/debug/slim`
+  paired with `/debug/wasm` (or `/debug/wasm-base64`). Previously the
+  "obvious" workaround of pairing `/slim` with `/debug/wasm` crashed
+  at the first call into the module with
+  `TypeError: wasm.__wbindgen_export3 is not a function`, because
+  `wasm-opt` renames wasm exports in the optimized variant and
+  `/slim`'s JS bindings are pinned to those renamed names.
+
 ## 0.2.3 - 17th April 2026
 
 * Add a --debug-variant flag which builds an additional /debug export which

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The package produced by `wasm-bodge` provides the following subpath exports whic
 | `./wasm-base64` | Base64-encoded wasm |
 | `./iife` | IIFE bundle for `<script>` tags |
 
+When built with `--debug-variant`, parallel `./debug`, `./debug/slim`, `./debug/wasm`, `./debug/wasm-base64`, and `./debug/iife` exports are added. They serve a wasm module compiled with DWARF preserved so it can be stepped through in browser devtools. To switch a given import to the debug variant, insert `debug` immediately after the package name: for example, `pkg` becomes `pkg/debug`, and `pkg/slim` becomes `pkg/debug/slim`.
+
 ---
 
 ## Table of Contents

--- a/src/build/entrypoints.rs
+++ b/src/build/entrypoints.rs
@@ -26,11 +26,6 @@ pub fn generate(out_dir: &Path, crate_name: &str) -> Result<()> {
 
         println!("  Generating ESM entrypoints ({})...", variant,);
         for env in Environment::all() {
-            // The debug variant doesn't expose a /debug/slim export, so skip
-            // generating the Slim entrypoint for it.
-            if variant.is_debug() && *env == Environment::Slim {
-                continue;
-            }
             let content = targets::generate_esm_entrypoint(*env, &wasm_name, *variant);
             let path = out_dir.join(targets::paths::esm_entrypoint(*env, *variant));
             std::fs::write(&path, content)?;
@@ -38,9 +33,6 @@ pub fn generate(out_dir: &Path, crate_name: &str) -> Result<()> {
 
         println!("  Generating CJS entrypoints ({})...", variant,);
         for env in Environment::all() {
-            if variant.is_debug() && *env == Environment::Slim {
-                continue;
-            }
             if let Some(content) = targets::generate_cjs_entrypoint(*env, &wasm_name, *variant) {
                 let path = out_dir.join(targets::paths::cjs_entrypoint(*env, *variant));
                 std::fs::write(&path, content)?;

--- a/src/build/package_json.rs
+++ b/src/build/package_json.rs
@@ -157,13 +157,29 @@ fn build_exports_map(dist: &str, package_name: &str, has_debug: bool) -> Value {
         json!(p(&targets::paths::iife_bundle(WasmVariant::Optimized))),
     );
 
-    // Debug variant exports: mirror ./, ./wasm, ./wasm-base64, ./iife.
-    // No ./debug/slim -- manual init makes the "skip auto-init" point moot
-    // and the debug variant already ships the unoptimized wasm.
+    // Debug variant exports: mirror ./, ./slim, ./wasm, ./wasm-base64, ./iife.
+    //
+    // `./debug/slim` is load-bearing, not just ergonomic: `wasm-opt`
+    // renames wasm exports in the optimized variant (see
+    // `cjs_web_bindings` in targets.rs), so the JS bindings re-exported by
+    // `./slim` are pinned to the optimized wasm's renamed symbol names. A
+    // consumer who pairs `./slim` with `./debug/wasm` hits a runtime
+    // `TypeError: wasm.__wbindgen_export3 is not a function` during the
+    // first call into the module. `./debug/slim` re-exports the debug
+    // variant's wasm-bindgen JS and must be used alongside `./debug/wasm`
+    // (or `./debug/wasm-base64`) as a matched pair.
     if has_debug {
         exports.insert(
             "./debug".to_string(),
             build_conditional_export(dist, WasmVariant::Debug),
+        );
+        exports.insert(
+            "./debug/slim".to_string(),
+            json!({
+                "types": p(&targets::paths::types()),
+                "import": p(&targets::paths::esm_entrypoint(Environment::Slim, WasmVariant::Debug)),
+                "require": p(&targets::paths::cjs_entrypoint(Environment::Slim, WasmVariant::Debug))
+            }),
         );
         exports.insert(
             "./debug/wasm".to_string(),

--- a/src/build/targets.rs
+++ b/src/build/targets.rs
@@ -543,6 +543,43 @@ mod tests {
     }
 
     #[test]
+    fn test_debug_slim_paths_and_content() {
+        // Paths: debug variant of the Slim environment should land in
+        // esm/debug-slim.js and cjs/debug-slim.cjs (mirroring the optimized
+        // slim entrypoints).
+        assert_eq!(
+            paths::esm_entrypoint(Environment::Slim, WasmVariant::Debug),
+            PathBuf::from("esm/debug-slim.js")
+        );
+        assert_eq!(
+            paths::cjs_entrypoint(Environment::Slim, WasmVariant::Debug),
+            PathBuf::from("cjs/debug-slim.cjs")
+        );
+
+        // ESM content: pure re-export from the debug wasm-bindgen output
+        // (no initialization, since Slim's InitStrategy is Manual).
+        let esm = generate_esm_entrypoint(Environment::Slim, "my_crate", WasmVariant::Debug);
+        assert!(
+            esm.contains("from '../wasm_bindgen/web-debug/my_crate.js'"),
+            "debug slim must re-export from web-debug, got:\n{}",
+            esm
+        );
+        assert!(
+            !esm.contains("initSync"),
+            "debug slim must not auto-initialize"
+        );
+
+        // CJS content: re-exports the debug variant's web-bindings bundle.
+        let cjs = generate_cjs_entrypoint(Environment::Slim, "my_crate", WasmVariant::Debug)
+            .expect("debug slim must generate a CJS entrypoint");
+        assert!(
+            cjs.contains("require('./debug-web-bindings.cjs')"),
+            "debug slim CJS must require ./debug-web-bindings.cjs, got:\n{}",
+            cjs
+        );
+    }
+
+    #[test]
     fn test_debug_entrypoint_uses_web_debug_js() {
         // Each variant references its own wasm-bindgen JS output because
         // wasm-opt rewrites wasm export names in the optimized variant and the

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -737,6 +737,161 @@ fn test_node_esm_debug() {
     run_test("node_esm_debug").unwrap();
 }
 
+/// End-to-end regression test for the `./debug/slim` + `./debug/wasm`
+/// pairing. Pre-v0.2.4, the "obvious" workaround of combining `./slim`
+/// (manual-init JS) with `./debug/wasm` (debug binary) crashed at the
+/// first call into the module with
+/// `TypeError: wasm.__wbindgen_export3 is not a function`, because
+/// `wasm-opt` renames the optimized variant's wasm exports and the
+/// `./slim` JS is pinned to that renamed ABI. This test proves that
+/// `./debug/slim` + `./debug/wasm` is a working matched pair by
+/// actually loading and calling into the debug wasm.
+#[test]
+fn test_node_esm_debug_slim() {
+    run_test("node_esm_debug_slim").unwrap();
+}
+
+/// The optimized and debug wasm-bindgen JS outputs reference divergent
+/// sets of wasm exports: `wasm-opt` renames wasm exports in the optimized
+/// variant (e.g. `__wbindgen_malloc` becomes `__wbindgen_export\d+`)
+/// while the debug variant skips `wasm-opt` and preserves the original
+/// wasm-bindgen names. The `./slim` JS is therefore pinned to the
+/// optimized variant's renamed symbols and cannot drive the debug wasm,
+/// which is why a separate `./debug/slim` export is required.
+///
+/// This test asserts the divergence _property_ rather than hard-coded
+/// symbol names: the two JS files must not be byte-identical, and the
+/// optimized file must reference at least one `wasm.__wbindgen_export\d+`
+/// symbol that the debug file does not. If that ever stops being true,
+/// the justification for maintaining a separate `./debug/slim` export
+/// needs re-examining.
+#[test]
+fn test_optimized_and_debug_bindings_have_divergent_symbols() {
+    let package_dir = get_test_package().unwrap();
+    let dist = package_dir.join("dist");
+
+    let optimized_js =
+        std::fs::read_to_string(dist.join("wasm_bindgen/web/test_wasm_lib.js")).unwrap();
+    let debug_js =
+        std::fs::read_to_string(dist.join("wasm_bindgen/web-debug/test_wasm_lib.js")).unwrap();
+
+    assert_ne!(
+        optimized_js, debug_js,
+        "optimized and debug wasm-bindgen JS must not be byte-identical -- \
+         if they are, `wasm-opt` may have stopped renaming exports and \
+         `./slim` could potentially drive the debug wasm directly"
+    );
+
+    // Collect every `wasm.__wbindgen_<symbol>` reference from each file.
+    let symbol_re = regex::Regex::new(r"wasm\.(__wbindgen_\w+)").unwrap();
+    let symbols_in = |src: &str| -> std::collections::BTreeSet<String> {
+        symbol_re
+            .captures_iter(src)
+            .map(|c| c[1].to_string())
+            .collect()
+    };
+    let optimized_symbols = symbols_in(&optimized_js);
+    let debug_symbols = symbols_in(&debug_js);
+
+    // The optimized variant must reference at least one wasm-opt-renamed
+    // symbol (`__wbindgen_export\d+`) that the debug variant does not.
+    let renamed_re = regex::Regex::new(r"^__wbindgen_export\d+$").unwrap();
+    let optimized_only_renamed: Vec<&String> = optimized_symbols
+        .difference(&debug_symbols)
+        .filter(|s| renamed_re.is_match(s))
+        .collect();
+
+    assert!(
+        !optimized_only_renamed.is_empty(),
+        "expected the optimized variant to reference at least one \
+         `wasm.__wbindgen_export\\d+` symbol absent from the debug \
+         variant; found optimized symbols: {:?}, debug symbols: {:?}",
+        optimized_symbols,
+        debug_symbols,
+    );
+}
+
+/// Verify that the `./debug/slim` subpath export is generated when
+/// `--debug-variant` is set: the ESM/CJS files exist, the `package.json`
+/// `exports` map contains a `./debug/slim` entry pointing at them, and the
+/// Slim entrypoint does not auto-initialize the wasm module.
+#[test]
+fn test_debug_slim_export() {
+    let package_dir = get_test_package().unwrap();
+    let dist = package_dir.join("dist");
+
+    // Both optimized and debug Slim entrypoints must exist.
+    let esm_slim = dist.join("esm/slim.js");
+    let esm_debug_slim = dist.join("esm/debug-slim.js");
+    let cjs_slim = dist.join("cjs/slim.cjs");
+    let cjs_debug_slim = dist.join("cjs/debug-slim.cjs");
+    assert!(esm_slim.exists(), "esm/slim.js missing");
+    assert!(
+        esm_debug_slim.exists(),
+        "esm/debug-slim.js missing: {}",
+        esm_debug_slim.display()
+    );
+    assert!(cjs_slim.exists(), "cjs/slim.cjs missing");
+    assert!(
+        cjs_debug_slim.exists(),
+        "cjs/debug-slim.cjs missing: {}",
+        cjs_debug_slim.display()
+    );
+
+    // The debug slim ESM entrypoint must re-export from wasm_bindgen/web-debug/
+    // and must not auto-initialize the module.
+    let esm_debug_slim_content = std::fs::read_to_string(&esm_debug_slim).unwrap();
+    assert!(
+        esm_debug_slim_content.contains("../wasm_bindgen/web-debug/"),
+        "esm/debug-slim.js should re-export from wasm_bindgen/web-debug/, got:\n{}",
+        esm_debug_slim_content
+    );
+    assert!(
+        !esm_debug_slim_content.contains("initSync"),
+        "esm/debug-slim.js must not auto-initialize, got:\n{}",
+        esm_debug_slim_content
+    );
+
+    // The debug slim CJS entrypoint must require the debug web-bindings bundle.
+    let cjs_debug_slim_content = std::fs::read_to_string(&cjs_debug_slim).unwrap();
+    assert!(
+        cjs_debug_slim_content.contains("./debug-web-bindings.cjs"),
+        "cjs/debug-slim.cjs should require ./debug-web-bindings.cjs, got:\n{}",
+        cjs_debug_slim_content
+    );
+
+    // package.json must declare a ./debug/slim export with import/require/types
+    // pointing at the debug entrypoints.
+    let package_json: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(package_dir.join("package.json")).unwrap(),
+    )
+    .unwrap();
+    let debug_slim = &package_json["exports"]["./debug/slim"];
+    assert!(
+        debug_slim.is_object(),
+        "package.json exports must contain a ./debug/slim entry, got: {}",
+        package_json["exports"]
+    );
+    let import = debug_slim["import"].as_str().unwrap_or("");
+    let require = debug_slim["require"].as_str().unwrap_or("");
+    let types = debug_slim["types"].as_str().unwrap_or("");
+    assert!(
+        import.ends_with("/esm/debug-slim.js"),
+        "./debug/slim import should end with /esm/debug-slim.js, got: {}",
+        import
+    );
+    assert!(
+        require.ends_with("/cjs/debug-slim.cjs"),
+        "./debug/slim require should end with /cjs/debug-slim.cjs, got: {}",
+        require
+    );
+    assert!(
+        types.ends_with("/index.d.ts"),
+        "./debug/slim types should end with /index.d.ts, got: {}",
+        types
+    );
+}
+
 /// Test that building with a scoped npm package name (e.g. @scope/name) works.
 #[test]
 fn test_scoped_package_name() {

--- a/tests/templates/node_esm_debug_slim/package.json
+++ b/tests/templates/node_esm_debug_slim/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "node-esm-debug-slim-test",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "true",
+    "test": "node test.mjs"
+  }
+}

--- a/tests/templates/node_esm_debug_slim/test.mjs
+++ b/tests/templates/node_esm_debug_slim/test.mjs
@@ -1,0 +1,30 @@
+// End-to-end regression test for the `/debug/slim` + `/debug/wasm` pairing.
+//
+// On wasm-bodge <=0.2.3, the "obvious" way to manually initialize the debug
+// wasm -- combine `/slim` (manual-init JS) with `/debug/wasm` (debug binary)
+// -- crashed at the first call into the module with
+// `TypeError: wasm.__wbindgen_export3 is not a function`. The cause: wasm-opt
+// renames wasm exports in the optimized variant, so `/slim`'s JS bindings
+// are pinned to the optimized ABI and cannot drive the debug wasm. This
+// test loads the debug wasm through `/debug/slim` (which re-exports the
+// debug variant's JS bindings) and calls into it, proving the matched-pair
+// combination works.
+import { add, greet, initSync } from 'test-wasm-lib/debug/slim';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const wasmPath = require.resolve('test-wasm-lib/debug/wasm');
+const wasmBytes = require('node:fs').readFileSync(wasmPath);
+initSync(wasmBytes);
+
+const result1 = add(2, 3);
+if (result1 !== 5) {
+  throw new Error(`add(2, 3) expected 5, got ${result1}`);
+}
+
+const result2 = greet('World');
+if (result2 !== 'Hello, World!') {
+  throw new Error(`greet("World") expected "Hello, World!", got ${result2}`);
+}
+
+console.log('WASM_BODGE_TEST_PASSED');


### PR DESCRIPTION
Adds `/debug/*` (e.g. `/debug/slim`) to mirror all of the production entrypoints. The idea is to improve the ergonomics so that a user can tack a `/debug` in their import and get the full debug output with no other code changes.

This PR also includes an ABI incompatibility bug that I was able to reproduce on `main` and appears solved on this branch.

There's a stacked PR coming that IMO is more important, which includes building the crate without stripping internal symnbols before handing off to various wasm tools

# Machine summary

> Confirmed: the ./slim + ./debug/wasm combination is broken on v0.2.3 (the "workaround" for manual-init debugging that `@alexjg`'s original comment suggested was sufficient), and this PR fixes it. The fix is the `./debug/slim` export, which re-exports the debug variant's wasm-bindgen JS so its ABI matches the debug wasm.
> So the PR has two dimensions, not one:
> 1. Feature: new `./debug/slim` subpath export for ergonomic parity with `./slim`.
> 2. Fix: manual-init debugging via `/slim` + `/debug/wasm` was unusable in v0.2.3 due to the wasm-opt ABI rename; `/debug/slim` + `/debug/wasm` is the working pairing.