### PR TITLE
Fix `initSync` deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+### Fixed
+
+* Generated entrypoints now call `initSync({ module: bytes })` instead
+  of the positional-bytes form `initSync(bytes)`, silencing the
+  `using deprecated parameters for initSync()` warning emitted by
+  wasm-bindgen 0.2.87+.
+
 ## 0.2.3 - 17th April 2026
 
 * Add a --debug-variant flag which builds an additional /debug export which

--- a/src/build/targets.rs
+++ b/src/build/targets.rs
@@ -363,7 +363,7 @@ import {{ readFileSync }} from 'node:fs';
 import {{ fileURLToPath }} from 'node:url';
 import {{ dirname, join }} from 'node:path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
-initSync(readFileSync(join(__dirname, '../{web_dir}/{name}_bg.wasm')));
+initSync({{ module: readFileSync(join(__dirname, '../{web_dir}/{name}_bg.wasm')) }});
 export * from '../{web_dir}/{name}.js';
 "#,
                 name = wasm_name,
@@ -376,7 +376,7 @@ export * from '../{web_dir}/{name}.js';
                 r#"import {{ initSync }} from '../{web_dir}/{name}.js';
 import {{ wasmBase64 }} from '{base64_import}';
 const bytes = Uint8Array.from(atob(wasmBase64), c => c.charCodeAt(0));
-initSync(bytes);
+initSync({{ module: bytes }});
 export * from '../{web_dir}/{name}.js';
 "#,
                 name = wasm_name,
@@ -447,7 +447,7 @@ pub fn generate_cjs_entrypoint(
                 r#"const bindings = require('{bindings_require}');
 const fs = require('fs');
 const path = require('path');
-bindings.initSync(fs.readFileSync(path.join(__dirname, '../{wasm_dir}/{name}_bg.wasm')));
+bindings.initSync({{ module: fs.readFileSync(path.join(__dirname, '../{wasm_dir}/{name}_bg.wasm')) }});
 module.exports = bindings;
 "#,
                 name = wasm_name,
@@ -562,5 +562,37 @@ mod tests {
         let node_opt =
             generate_esm_entrypoint(Environment::Node, "my_crate", WasmVariant::Optimized);
         assert!(node_opt.contains("from '../wasm_bindgen/web/my_crate.js'"));
+    }
+
+    /// Fail if any generated entrypoint uses the deprecated
+    /// positional-bytes form of `initSync`
+    /// (wasm-bindgen deprecated it in 0.2.87 in favor of `initSync({ module: ... })`).
+    #[test]
+    fn test_no_deprecated_init_sync_form() {
+        let re = regex::Regex::new(r"initSync\(\s*([^{\s])").unwrap();
+
+        let mut generated = Vec::new();
+        for env in Environment::all() {
+            for variant in WasmVariant::all() {
+                generated.push((
+                    format!("esm[{:?}, {:?}]", env, variant),
+                    generate_esm_entrypoint(*env, "my_crate", *variant),
+                ));
+                if let Some(cjs) = generate_cjs_entrypoint(*env, "my_crate", *variant) {
+                    generated.push((format!("cjs[{:?}, {:?}]", env, variant), cjs));
+                }
+            }
+        }
+
+        for (label, src) in &generated {
+            if let Some(cap) = re.captures(src) {
+                panic!(
+                    "{} uses the deprecated positional-bytes form of initSync; \
+                     matched `initSync({}...)`. Use `initSync({{ module: ... }})` \
+                     instead.\n--- generated source ---\n{}",
+                    label, &cap[1], src
+                );
+            }
+        }
     }
 }

--- a/tests/templates/node_cjs_slim/test.cjs
+++ b/tests/templates/node_cjs_slim/test.cjs
@@ -4,7 +4,7 @@ const fs = require('fs');
 // Initialize wasm manually using the package's wasm export
 const wasmPath = require.resolve('test-wasm-lib/wasm');
 const wasmBytes = fs.readFileSync(wasmPath);
-initSync(wasmBytes);
+initSync({ module: wasmBytes });
 
 // Run tests
 const result1 = add(2, 3);

--- a/tests/templates/node_esm_slim/test.mjs
+++ b/tests/templates/node_esm_slim/test.mjs
@@ -5,7 +5,7 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const wasmPath = require.resolve('test-wasm-lib/wasm');
 const wasmBytes = require('node:fs').readFileSync(wasmPath);
-initSync(wasmBytes);
+initSync({ module: wasmBytes });
 
 // Run tests
 const result1 = add(2, 3);

--- a/tests/templates/vite_build_slim/main.js
+++ b/tests/templates/vite_build_slim/main.js
@@ -5,7 +5,7 @@ try {
   // Fetch and initialize wasm
   const response = await fetch(wasmUrl);
   const bytes = await response.arrayBuffer();
-  initSync(new Uint8Array(bytes));
+  initSync({ module: new Uint8Array(bytes) });
 
   const result1 = add(2, 3);
   const result2 = greet('World');

--- a/tests/templates/vite_dev_slim/main.js
+++ b/tests/templates/vite_dev_slim/main.js
@@ -5,7 +5,7 @@ try {
   // Fetch and initialize wasm
   const response = await fetch(wasmUrl);
   const bytes = await response.arrayBuffer();
-  initSync(new Uint8Array(bytes));
+  initSync({ module: new Uint8Array(bytes) });
 
   const result1 = add(2, 3);
   const result2 = greet('World');

--- a/tests/templates/workerd_slim/worker.js
+++ b/tests/templates/workerd_slim/worker.js
@@ -3,7 +3,7 @@ import { wasmBase64 } from 'test-wasm-lib/wasm-base64';
 
 // Initialize wasm from base64
 const bytes = Uint8Array.from(atob(wasmBase64), (c) => c.charCodeAt(0));
-initSync(bytes);
+initSync({ module: bytes });
 
 export default {
   async fetch(request) {


### PR DESCRIPTION
`initSync(...)` is deprecated. This PR changes the calling convention to the current `initSync({module: ...})`