### PR TITLE
Ability to retain DWARF symbols with separate debug profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@
   `using deprecated parameters for initSync()` warning emitted by
   wasm-bindgen 0.2.87+.
 
+### Added
+
+* `--release-profile <name>` CLI flag (alias of the existing `--profile`) for the release variant, default `release`.
+* `--debug-profile <name>` CLI flag. Passing it drives a second `cargo build --profile <name>` and exposes the resulting wasm via `/debug/*` subpath exports. No default: if you don't pass the flag, no debug variant is built. With the recommended `inherits = "dev"` profile, the `/debug` variant is a full Rust dev build (DWARF + debug assertions + overflow checks + opt-level 0) with DWARF preserved through `wasm-bindgen --keep-debug`.
+
+### Removed
+
+* `--debug-variant` flag. Debug variants are now requested by passing `--debug-profile <name>` with an explicit profile name. See the Breaking Changes section for migration.
+
+### Changed
+
+* Debug variants are no longer produced by copying the already-compiled release wasm into a `/debug` slot. Previously the approach silently produced useless debug artifacts whenever the consumer's `[profile.release]` did not preserve DWARF (the Rust default). Only a dedicated profile gets DWARF, debug assertions, overflow checks, and low optimization into the packaged `/debug/*` output regardless of how the release profile is configured.
+
+### Breaking Changes
+
+* `--debug-variant` has been removed. The replacement is `--debug-profile <name>`: declare a `[profile.<name>]` section in the authoritative `Cargo.toml` (the workspace root for workspace members, or the crate's own manifest for standalone crates), then pass `--debug-profile <name>`. If the named profile is not declared, wasm-bodge fails with an error. If your v0.2.3 invocation was `wasm-bodge build --debug-variant` and it worked because `[profile.release]` had `debug = true`, you have two migration paths: (a) recommended — add a `[profile.wasm-debug]` section with `inherits = "dev"` for a proper debug build, then pass `--debug-profile wasm-debug`; (b) minimal — pass `--debug-profile release` to reuse the release profile. Option (b) preserves DWARF but not debug assertions, overflow checks, or recognizable variable scopes.
+
 ## 0.2.3 - 17th April 2026
 
 * Add a --debug-variant flag which builds an additional /debug export which

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ wasm-bodge build [OPTIONS]
 | `--crate-path <PATH>` | `.` (current dir) | Path to the Rust crate directory |
 | `--package-json <PATH>` | `./package.json` | Path to template package.json |
 | `--out-dir <PATH>` | `./dist` | Output directory for generated files |
-| `--profile <PROFILE>` | `release` | Cargo build profile |
+| `--release-profile <PROFILE>` | `release` | Cargo profile for the release variant (alias: `--profile`) |
+| `--debug-profile <PROFILE>` | (none) | Passing this flag builds a parallel `/debug` variant using the named profile |
 | `--wasm-bindgen-tar <PATH>` | (none) | Use prebuilt wasm-bindgen output from tarball |
 | `--no-wasm-opt` | `false` | Skip wasm-opt optimization |
 
@@ -99,6 +100,26 @@ wasm-bodge build [OPTIONS]
 - `wasm-bindgen-cli` (`cargo install wasm-bindgen-cli`)
 - `wasm-opt` (`cargo install wasm-opt`) — disable with `--no-wasm-opt`
 - `esbuild` (`npm install -g esbuild` or local install)
+
+### Debug builds
+
+Passing `--debug-profile <name>` produces a parallel `./debug` subpath export compiled under the named cargo profile. With the recommended `inherits = "dev"` profile below, the `/debug` artifacts have DWARF for browser devtools, runtime debug assertions, arithmetic overflow checks, and a low `opt-level` that keeps variable scopes and line numbers intact. The release variant is untouched.
+
+The named profile must exist in the authoritative `Cargo.toml`: the standalone crate's manifest, or the workspace root's manifest for workspace members (cargo reads `[profile.*]` only from the workspace root and silently ignores profile tables in member manifests). Recommended snippet:
+
+```toml
+[profile.wasm-debug]
+inherits = "dev"
+debug = "full"
+opt-level = 0
+strip = "none"
+```
+
+Then invoke: `wasm-bodge build --debug-profile wasm-debug`.
+
+wasm-bodge runs two independent `cargo build` invocations — one with `--release-profile` (default `release`), one with `--debug-profile` — and feeds each to `wasm-bindgen` independently. `wasm-opt` is only applied to the release wasm.
+
+If the named profile is not declared, wasm-bodge fails with an error pointing you at the snippet above. `--debug-profile release` gives you a debug variant with DWARF but without the debug assertions, low opt-level, or overflow checks of a `dev`-inherited profile.
 
 ---
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -32,9 +32,9 @@ pub fn run(config: BuildConfig) -> Result<()> {
         wasm_bindgen::build_wasm(
             crate_path,
             &wasm_bindgen_dir,
-            &config.profile,
+            &config.release_profile,
+            config.debug_profile.as_deref(),
             config.wasm_opt,
-            config.debug_variant,
         )?;
     }
 
@@ -55,7 +55,7 @@ pub fn run(config: BuildConfig) -> Result<()> {
 
     // Phase 4: Finalize package
     println!("Phase 4: Finalizing package...");
-    let available_variants = if config.debug_variant {
+    let available_variants = if config.debug_profile.is_some() {
         WasmVariant::all()
     } else {
         &[WasmVariant::Optimized]

--- a/src/build/wasm_bindgen.rs
+++ b/src/build/wasm_bindgen.rs
@@ -1,25 +1,66 @@
 use anyhow::{Context, Result};
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use super::targets::{WasmBindgenTarget, WasmVariant};
 
-/// Build wasm and run wasm-bindgen for all targets. When `debug_variant` is
-/// true, also builds a parallel debug variant (DWARF preserved) under
-/// `web-debug/` and `bundler-debug/`.
+/// Build wasm and run wasm-bindgen for all targets. When `debug_profile`
+/// is `Some(name)`, also drives `cargo build --profile <name>` to produce
+/// a parallel wasm with DWARF preserved.
 pub fn build_wasm(
     crate_path: &Path,
     output_dir: &Path,
-    profile: &str,
+    release_profile: &str,
+    debug_profile: Option<&str>,
     wasm_opt: bool,
-    debug_variant: bool,
 ) -> Result<()> {
-    // Build the Rust crate
-    println!("  Building Rust crate...");
-    let cargo_profile = if profile == "release" {
-        "--release"
+    // Resolve `target_dir` and `wasm_name` once: both are invariant across
+    // the release and debug builds, and each call to `find_target_dir`
+    // spawns `cargo metadata` while `get_crate_name` reparses `Cargo.toml`.
+    let target_dir = find_target_dir(crate_path)?;
+    let wasm_name = get_crate_name(crate_path)?.replace('-', "_");
+
+    println!("  Building Rust crate (profile: {release_profile})...");
+    cargo_build(crate_path, release_profile)?;
+    let release_wasm = wasm_artifact_path(&target_dir, &wasm_name, release_profile)?;
+
+    let debug_wasm: Option<PathBuf> = match debug_profile {
+        Some(profile) => {
+            println!("  Building Rust crate (profile: {profile}, for debug variant)...");
+            cargo_build_debug_profile(crate_path, profile)?;
+            Some(wasm_artifact_path(&target_dir, &wasm_name, profile)?)
+        }
+        None => None,
+    };
+
+    if wasm_opt {
+        println!("  Running wasm-opt on release variant...");
+        run_wasm_opt(&release_wasm)?;
+    }
+
+    std::fs::create_dir_all(output_dir)?;
+
+    for target in WasmBindgenTarget::all() {
+        run_wasm_bindgen(&release_wasm, output_dir, *target, WasmVariant::Optimized)?;
+    }
+
+    if let Some(debug_wasm) = debug_wasm.as_deref() {
+        for target in [WasmBindgenTarget::Web, WasmBindgenTarget::Bundler] {
+            run_wasm_bindgen(debug_wasm, output_dir, target, WasmVariant::Debug)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn cargo_build(crate_path: &Path, profile: &str) -> Result<()> {
+    let profile_arg = if profile == "release" {
+        "--release".to_string()
     } else {
-        &format!("--profile={}", profile)
+        format!("--profile={profile}")
     };
 
     let status = Command::new("cargo")
@@ -27,7 +68,7 @@ pub fn build_wasm(
             "build",
             "--target",
             "wasm32-unknown-unknown",
-            cargo_profile,
+            &profile_arg,
             "--manifest-path",
             &crate_path.join("Cargo.toml").to_string_lossy(),
         ])
@@ -35,68 +76,94 @@ pub fn build_wasm(
         .context("Failed to run cargo build")?;
 
     if !status.success() {
-        anyhow::bail!("cargo build failed");
+        anyhow::bail!("cargo build failed for profile `{profile}`");
     }
+    Ok(())
+}
 
-    // Find the wasm file
-    let target_dir = find_target_dir(crate_path)?;
-    let profile_dir = if profile == "release" {
-        "release"
-    } else {
-        profile
-    };
-    let crate_name = get_crate_name(crate_path)?;
-    let wasm_name = crate_name.replace('-', "_");
-    let wasm_file = target_dir
-        .join("wasm32-unknown-unknown")
-        .join(profile_dir)
-        .join(format!("{}.wasm", wasm_name));
+/// Like `cargo_build`, but wraps cargo's "profile not defined" error with
+/// a snippet users can paste into `Cargo.toml`.
+fn cargo_build_debug_profile(crate_path: &Path, profile: &str) -> Result<()> {
+    // Tee stderr so cargo's progress still streams live while we keep a
+    // copy for post-hoc error classification.
+    let mut child = Command::new("cargo")
+        .args([
+            "build",
+            "--target",
+            "wasm32-unknown-unknown",
+            &format!("--profile={profile}"),
+            "--manifest-path",
+            &crate_path.join("Cargo.toml").to_string_lossy(),
+        ])
+        .env("LANG", "C")
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .context("Failed to spawn cargo build")?;
 
-    if !wasm_file.exists() {
-        anyhow::bail!("Wasm file not found at {:?}", wasm_file);
-    }
-
-    // If a debug variant is requested, copy the source wasm (with DWARF) to a
-    // sibling subdirectory so the debug wasm-bindgen run has its own pristine
-    // input. Preserving the file stem keeps wasm-bindgen's output filenames
-    // consistent across variants.
-    //
-    // We do NOT run wasm-opt on the debug variant: binaryen's DWARF support is
-    // incomplete and cannot process the DWARF that wasm-bindgen (walrus)
-    // rewrites, so any `wasm-opt -g` pass on wasm-bindgen's `--keep-debug`
-    // output fails with a `debug_loc error`. Running wasm-opt without `-g`
-    // would strip debug symbols, defeating the point of the debug variant.
-    let debug_wasm_file = if debug_variant {
-        let debug_wasm_dir = wasm_file.parent().unwrap().join("_wasm_bodge_debug");
-        std::fs::create_dir_all(&debug_wasm_dir)?;
-        let path = debug_wasm_dir.join(format!("{}.wasm", wasm_name));
-        std::fs::copy(&wasm_file, &path).context("Failed to copy wasm for debug variant")?;
-        Some(path)
-    } else {
-        None
-    };
-
-    if wasm_opt {
-        println!("  Running wasm-opt (optimized, strips debug symbols)...");
-        run_wasm_opt(&wasm_file)?;
-    }
-
-    std::fs::create_dir_all(output_dir)?;
-
-    // Optimized variant: run wasm-bindgen for all targets (nodejs, web, bundler)
-    for target in WasmBindgenTarget::all() {
-        run_wasm_bindgen(&wasm_file, output_dir, *target, WasmVariant::Optimized)?;
-    }
-
-    // Debug variant: run wasm-bindgen --keep-debug for web + bundler. No
-    // wasm-opt pass (see above).
-    if let Some(debug_wasm_file) = debug_wasm_file.as_deref() {
-        for target in [WasmBindgenTarget::Web, WasmBindgenTarget::Bundler] {
-            run_wasm_bindgen(debug_wasm_file, output_dir, target, WasmVariant::Debug)?;
+    let mut captured_stderr = Vec::new();
+    if let Some(mut child_stderr) = child.stderr.take() {
+        let mut buf = [0u8; 4096];
+        loop {
+            match child_stderr.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    captured_stderr.extend_from_slice(&buf[..n]);
+                    let _ = std::io::stderr().write_all(&buf[..n]);
+                }
+                Err(e) => return Err(e).context("Failed to read cargo stderr"),
+            }
         }
     }
 
-    Ok(())
+    let status = child.wait().context("Failed to wait on cargo build")?;
+    if status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&captured_stderr);
+    let needle = format!("profile `{profile}` is not defined");
+    let profile_missing = stderr
+        .lines()
+        .any(|line| line.starts_with("error:") && line.contains(&needle));
+    if profile_missing {
+        anyhow::bail!(
+            "--debug-profile {profile} requires a [profile.{profile}] section \
+             in your Cargo.toml (or in the workspace root's Cargo.toml if this \
+             crate is a workspace member -- cargo reads [profile.*] only from \
+             the workspace root).\n\n\
+             Recommended snippet:\n\n    \
+             [profile.{profile}]\n    \
+             inherits = \"dev\"\n    \
+             debug = \"full\"\n    \
+             opt-level = 0\n    \
+             strip = \"none\"\n\n\
+             Or pass --debug-profile <other-name> to use a profile you already have."
+        );
+    }
+
+    anyhow::bail!("cargo build failed for profile `{profile}`")
+}
+
+fn wasm_artifact_path(target_dir: &Path, wasm_name: &str, profile: &str) -> Result<PathBuf> {
+    let path = target_dir
+        .join("wasm32-unknown-unknown")
+        .join(profile_dir_name(profile))
+        .join(format!("{wasm_name}.wasm"));
+
+    if !path.exists() {
+        anyhow::bail!("Wasm file not found at {path:?}");
+    }
+    Ok(path)
+}
+
+/// Cargo maps `dev`/`test` to `debug/` and `bench` to `release/`;
+/// custom profiles use their own name.
+fn profile_dir_name(profile: &str) -> &str {
+    match profile {
+        "dev" | "test" => "debug",
+        "release" | "bench" => "release",
+        other => other,
+    }
 }
 
 fn run_wasm_opt(wasm_file: &Path) -> Result<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,9 +6,8 @@ pub struct BuildConfig {
     pub crate_path: PathBuf,
     pub package_json: PathBuf,
     pub out_dir: PathBuf,
-    pub profile: String,
+    pub release_profile: String,
+    pub debug_profile: Option<String>,
     pub wasm_bindgen_tar: Option<PathBuf>,
     pub wasm_opt: bool,
-    /// Also build a debug variant (DWARF preserved) exposed as `./debug`.
-    pub debug_variant: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,9 +29,16 @@ enum Commands {
         #[arg(long, default_value = "./dist")]
         out_dir: PathBuf,
 
-        /// Cargo build profile
-        #[arg(long, default_value = "release")]
-        profile: String,
+        /// Cargo build profile for the release variant (optimized; wasm-opt
+        /// applied unless --no-wasm-opt is set).
+        #[arg(long, alias = "profile", default_value = "release")]
+        release_profile: String,
+
+        /// Cargo build profile for the debug variant. Passing this flag also
+        /// builds a parallel `/debug` subpath export. Profile name must
+        /// match a `[profile.<name>]` section in the authoritative Cargo.toml.
+        #[arg(long)]
+        debug_profile: Option<String>,
 
         /// Use prebuilt wasm-bindgen output from tarball
         #[arg(long)]
@@ -40,11 +47,6 @@ enum Commands {
         /// Disable wasm-opt optimization
         #[arg(long, default_value_t = false)]
         no_wasm_opt: bool,
-
-        /// Also build a debug variant (DWARF symbols preserved) and expose it
-        /// via a `/debug` subpath export. Significantly inflates package size.
-        #[arg(long, default_value_t = false)]
-        debug_variant: bool,
     },
 }
 
@@ -56,19 +58,19 @@ fn main() -> Result<()> {
             crate_path,
             package_json,
             out_dir,
-            profile,
+            release_profile,
+            debug_profile,
             wasm_bindgen_tar,
             no_wasm_opt,
-            debug_variant,
         } => {
             let config = config::BuildConfig {
                 crate_path,
                 package_json,
                 out_dir,
-                profile,
+                release_profile,
+                debug_profile,
                 wasm_bindgen_tar,
                 wasm_opt: !no_wasm_opt,
-                debug_variant,
             };
             build::run(config)?;
         }

--- a/tests/fixtures/test-crate/Cargo.toml
+++ b/tests/fixtures/test-crate/Cargo.toml
@@ -11,3 +11,9 @@ wasm-bindgen = "=0.2.108"
 
 [profile.release]
 debug = true
+
+[profile.wasm-debug]
+inherits = "dev"
+debug = "full"
+opt-level = 0
+strip = "none"

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -28,6 +28,14 @@ fn get_test_package() -> Result<PathBuf> {
     }
 }
 
+const TEST_PACKAGE_JSON: &str = r#"{
+  "name": "test-wasm-lib",
+  "version": "0.1.0",
+  "license": "MIT",
+  "description": "Test fixture for wasm-bodge"
+}
+"#;
+
 /// Copy the test fixture crate's source files to a destination directory,
 /// excluding build artifacts (dist/, target/).
 fn copy_fixture_crate(dest: &Path) -> Result<(), String> {
@@ -44,8 +52,6 @@ fn copy_fixture_crate(dest: &Path) -> Result<(), String> {
 }
 
 fn build_test_package() -> Result<PathBuf, String> {
-    let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-
     // Copy fixture to a temp directory so we don't modify the repo
     let crate_path = std::env::temp_dir().join("wasm-bodge-test-build");
     let _ = std::fs::remove_dir_all(&crate_path);
@@ -54,40 +60,24 @@ fn build_test_package() -> Result<PathBuf, String> {
     let package_json = crate_path.join("package.json");
     let out_dir = crate_path.join("dist");
 
-    std::fs::write(
+    std::fs::write(&package_json, TEST_PACKAGE_JSON)
+        .map_err(|e| format!("Failed to write package.json: {e}"))?;
+
+    // Build with a debug variant so the debug-symbol and ./debug export
+    // tests can run against the same cached build.
+    let output = run_wasm_bodge_build(
+        &crate_path,
         &package_json,
-        r#"{
-  "name": "test-wasm-lib",
-  "version": "0.1.0",
-  "license": "MIT",
-  "description": "Test fixture for wasm-bodge"
-}
-"#,
-    )
-    .map_err(|e| format!("Failed to write package.json: {}", e))?;
+        &out_dir,
+        &["--debug-profile", "wasm-debug"],
+    );
 
-    // Build using cargo run. We pass --debug-variant so the debug-symbol and
-    // ./debug export tests can run against the same cached build.
-    let status = Command::new("cargo")
-        .args([
-            "run",
-            "--release",
-            "--",
-            "build",
-            "--crate-path",
-            crate_path.to_str().unwrap(),
-            "--package-json",
-            package_json.to_str().unwrap(),
-            "--out-dir",
-            out_dir.to_str().unwrap(),
-            "--debug-variant",
-        ])
-        .current_dir(&project_root)
-        .status()
-        .map_err(|e| format!("Failed to run cargo: {}", e))?;
-
-    if !status.success() {
-        return Err("wasm-bodge build failed".to_string());
+    if !output.status.success() {
+        return Err(format!(
+            "wasm-bodge build failed:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        ));
     }
 
     // Return the crate_path (where package.json lives), not out_dir
@@ -728,7 +718,7 @@ fn test_debug_symbols() {
     );
     assert!(
         has_debug_sections(&debug).unwrap(),
-        "debug wasm should have .debug_* sections (preserved by wasm-opt -g)"
+        "debug wasm should have .debug_* sections (preserved by the dedicated debug profile)"
     );
 }
 
@@ -740,8 +730,6 @@ fn test_node_esm_debug() {
 /// Test that building with a scoped npm package name (e.g. @scope/name) works.
 #[test]
 fn test_scoped_package_name() {
-    let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-
     let crate_copy = std::env::temp_dir().join("wasm-bodge-test-scoped");
     let _ = std::fs::remove_dir_all(&crate_copy);
     copy_fixture_crate(&crate_copy).unwrap();
@@ -761,24 +749,15 @@ fn test_scoped_package_name() {
     .unwrap();
 
     let out_dir = crate_copy.join("dist");
-    let status = Command::new("cargo")
-        .args([
-            "run",
-            "--release",
-            "--",
-            "build",
-            "--crate-path",
-            crate_copy.to_str().unwrap(),
-            "--package-json",
-            package_json.to_str().unwrap(),
-            "--out-dir",
-            out_dir.to_str().unwrap(),
-        ])
-        .current_dir(&project_root)
-        .status()
-        .expect("Failed to run cargo");
+    let output = run_wasm_bodge_build(&crate_copy, &package_json, &out_dir, &[]);
 
-    assert!(status.success(), "wasm-bodge build failed");
+    assert!(
+        output.status.success(),
+        "wasm-bodge build failed with status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
 
     // Verify key output files exist
     assert!(out_dir.join("index.d.ts").exists(), "index.d.ts missing");
@@ -794,4 +773,201 @@ fn test_scoped_package_name() {
 
     // Cleanup
     let _ = std::fs::remove_dir_all(&crate_copy);
+}
+
+fn run_wasm_bodge_build(
+    crate_path: &Path,
+    package_json: &Path,
+    out_dir: &Path,
+    extra_args: &[&str],
+) -> std::process::Output {
+    let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut args = vec![
+        "run",
+        "--release",
+        "--",
+        "build",
+        "--crate-path",
+        crate_path.to_str().unwrap(),
+        "--package-json",
+        package_json.to_str().unwrap(),
+        "--out-dir",
+        out_dir.to_str().unwrap(),
+    ];
+    args.extend(extra_args);
+
+    Command::new("cargo")
+        .args(&args)
+        .current_dir(&project_root)
+        .env("CARGO_TERM_COLOR", "never")
+        .output()
+        .expect("Failed to run cargo")
+}
+
+fn write_test_package_json(path: &Path) {
+    std::fs::write(path, TEST_PACKAGE_JSON).expect("Failed to write package.json");
+}
+
+/// With `[profile.wasm-debug]` declared, the debug variant is compiled by a
+/// dedicated cargo build (not copied from the release wasm).
+#[test]
+fn test_two_profile_debug_build() {
+    let crate_path = std::env::temp_dir().join("wasm-bodge-test-two-profile");
+    let _ = std::fs::remove_dir_all(&crate_path);
+    copy_fixture_crate(&crate_path).unwrap();
+
+    let package_json = crate_path.join("package.json");
+    write_test_package_json(&package_json);
+    let out_dir = crate_path.join("dist");
+
+    let output = run_wasm_bodge_build(
+        &crate_path,
+        &package_json,
+        &out_dir,
+        &["--debug-profile", "wasm-debug"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "wasm-bodge build failed:\nstdout: {stdout}\nstderr: {stderr}",
+    );
+
+    let debug_artifact =
+        crate_path.join("target/wasm32-unknown-unknown/wasm-debug/test_wasm_lib.wasm");
+    let debug_artifact_display = debug_artifact.display();
+    assert!(
+        debug_artifact.exists(),
+        "expected debug-profile artifact at {debug_artifact_display}",
+    );
+
+    let release_wasm = out_dir.join("test-wasm-lib.wasm");
+    let debug_wasm = out_dir.join("test-wasm-lib-debug.wasm");
+    assert!(
+        !has_debug_sections(&release_wasm).unwrap(),
+        "release wasm should have no DWARF"
+    );
+    assert!(
+        has_debug_sections(&debug_wasm).unwrap(),
+        "debug wasm should have DWARF"
+    );
+
+    let _ = std::fs::remove_dir_all(&crate_path);
+}
+
+/// Passing `--debug-profile <name>` where `[profile.<name>]` is not declared
+/// fails with a wrapped error pointing the user at the required snippet.
+#[test]
+fn test_missing_profile_is_hard_error() {
+    let crate_path = std::env::temp_dir().join("wasm-bodge-test-missing-profile");
+    let _ = std::fs::remove_dir_all(&crate_path);
+    copy_fixture_crate(&crate_path).unwrap();
+
+    let package_json = crate_path.join("package.json");
+    write_test_package_json(&package_json);
+    let out_dir = crate_path.join("dist");
+
+    // Pass a profile name that is guaranteed not to exist in the fixture's
+    // Cargo.toml so the build hits the missing-profile hard-error path.
+    let missing_profile = "definitely-not-declared";
+    let output = run_wasm_bodge_build(
+        &crate_path,
+        &package_json,
+        &out_dir,
+        &["--debug-profile", missing_profile],
+    );
+
+    assert!(
+        !output.status.success(),
+        "wasm-bodge should fail when [profile.{missing_profile}] is missing"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let expected =
+        format!("--debug-profile {missing_profile} requires a [profile.{missing_profile}]");
+    assert!(
+        stderr.contains(&expected),
+        "expected wasm-bodge-branded error mentioning --debug-profile and \
+         [profile.{missing_profile}], got:\n{stderr}",
+    );
+
+    let _ = std::fs::remove_dir_all(&crate_path);
+}
+
+/// `--debug-profile <name>` drives the build with the named profile.
+#[test]
+fn test_custom_debug_profile_name() {
+    let crate_path = std::env::temp_dir().join("wasm-bodge-test-custom-profile");
+    let _ = std::fs::remove_dir_all(&crate_path);
+    copy_fixture_crate(&crate_path).unwrap();
+
+    let cargo_toml = crate_path.join("Cargo.toml");
+    let existing = std::fs::read_to_string(&cargo_toml).unwrap();
+    std::fs::write(
+        &cargo_toml,
+        format!("{existing}\n\n[profile.my-weird-debug]\ninherits = \"dev\"\ndebug = \"full\"\n",),
+    )
+    .unwrap();
+
+    let package_json = crate_path.join("package.json");
+    write_test_package_json(&package_json);
+    let out_dir = crate_path.join("dist");
+
+    let output = run_wasm_bodge_build(
+        &crate_path,
+        &package_json,
+        &out_dir,
+        &["--debug-profile", "my-weird-debug"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "build failed:\nstdout: {stdout}\nstderr: {stderr}",
+    );
+
+    let artifact =
+        crate_path.join("target/wasm32-unknown-unknown/my-weird-debug/test_wasm_lib.wasm");
+    let artifact_display = artifact.display();
+    assert!(
+        artifact.exists(),
+        "expected custom-profile artifact at {artifact_display}",
+    );
+
+    let _ = std::fs::remove_dir_all(&crate_path);
+}
+
+/// `--debug-profile release` reuses the release profile for the debug
+/// variant (v0.2.3 migration path).
+#[test]
+fn test_debug_profile_release_migration() {
+    let crate_path = std::env::temp_dir().join("wasm-bodge-test-release-migration");
+    let _ = std::fs::remove_dir_all(&crate_path);
+    copy_fixture_crate(&crate_path).unwrap();
+
+    let package_json = crate_path.join("package.json");
+    write_test_package_json(&package_json);
+    let out_dir = crate_path.join("dist");
+
+    let output = run_wasm_bodge_build(
+        &crate_path,
+        &package_json,
+        &out_dir,
+        &["--debug-profile", "release"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "build failed:\nstdout: {stdout}\nstderr: {stderr}",
+    );
+
+    let debug_wasm = out_dir.join("test-wasm-lib-debug.wasm");
+    assert!(debug_wasm.exists(), "debug wasm missing");
+    assert!(
+        has_debug_sections(&debug_wasm).unwrap(),
+        "debug wasm should have DWARF (inherited from [profile.release] debug=true)"
+    );
+
+    let _ = std::fs::remove_dir_all(&crate_path);
 }

--- a/wasm-bodge.md
+++ b/wasm-bodge.md
@@ -435,9 +435,32 @@ The tool will preserve all fields and add the necessary `exports`, `main`,
 | `--package-json <path>` | No | `./package.json` | Template package.json |
 | `--out-dir <path>` | No | `./dist` | Output directory |
 | `--wasm-bindgen-tar <path>` | No | - | Use prebuilt wasm-bindgen output |
-| `--profile <name>` | No | `release` | Cargo build profile |
+| `--release-profile <name>` | No | `release` | Cargo profile for the release variant (alias: `--profile`) |
+| `--debug-profile <name>` | No | (none) | Passing this flag builds a parallel `/debug` variant using the named profile |
+| `--no-wasm-opt` | No | `false` | Skip wasm-opt optimization on the release variant |
 
 *Not required if `--wasm-bindgen-tar` is provided.
+
+### 6.2.1 Debug Variant
+
+Passing `--debug-profile <name>` makes wasm-bodge drive two independent cargo builds:
+
+1. `cargo build --profile <release-profile>` — produces the optimized wasm that backs the top-level subpath exports. `wasm-opt` is applied to this one.
+2. `cargo build --profile <name>` — produces the debug wasm that backs `/debug/*`. `wasm-opt` is *not* applied.
+
+Two separate builds, rather than reusing the release artifact, because a release wasm can carry DWARF but not debug assertions, overflow checks, or unoptimized variable scopes. A `dev`-inherited debug profile gives the debug variant DWARF symbols for browser devtools, runtime debug assertions, arithmetic overflow checks, and a low `opt-level` that keeps variable scopes and line numbers lined up with the source.
+
+The named profile must be declared where cargo looks for it: in the standalone crate's `Cargo.toml`, or, for workspace members, in the workspace root's `Cargo.toml` (cargo silently ignores `[profile.*]` in member manifests). If it is not, wasm-bodge fails with an error pointing the user at the required snippet.
+
+Recommended profile:
+
+```toml
+[profile.wasm-debug]
+inherits = "dev"
+debug = "full"
+opt-level = 0
+strip = "none"
+```
 
 ### 6.3 Optional Config File
 


### PR DESCRIPTION
This PR replaces `--debug-variant` with `--debug-profile <name>`. `--debug-variant` reused the release wasm, which could produce debug artifacts with no / fewer DWARF symbols (unless [profile.release] preserved all DWARF). `--debug-profile <name>` now drives a dedicated cargo build. The profile that you pass to it could be _anything_, so you can make a wasm-specific debug build separate from a profile for x86/ARM (for example).

I tried it with VERY different flags just to make sure that it would show up. Yep... those are pretty different builds in the output :laughing: 

```
-rw-r--r--  1 expede users  60M Apr 20 23:21 subduction-debug.wasm
-rw-r--r--  1 expede users 1.2M Apr 20 23:21 subduction.wasm
```