### PR TITLE
Add /debug/slim export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install wasm-bindgen-cli
         run: |
           # Download prebuilt binary instead of compiling from source
-          VERSION="0.2.108"
+          VERSION="0.2.120"
           curl -sSL "https://github.com/wasm-bindgen/wasm-bindgen/releases/download/$VERSION/wasm-bindgen-$VERSION-x86_64-unknown-linux-musl.tar.gz" | tar xz
           sudo mv "wasm-bindgen-$VERSION-x86_64-unknown-linux-musl/wasm-bindgen" /usr/local/bin/
           wasm-bindgen --version

--- a/src/build/entrypoints.rs
+++ b/src/build/entrypoints.rs
@@ -26,11 +26,6 @@ pub fn generate(out_dir: &Path, crate_name: &str) -> Result<()> {
 
         println!("  Generating ESM entrypoints ({})...", variant,);
         for env in Environment::all() {
-            // The debug variant doesn't expose a /debug/slim export, so skip
-            // generating the Slim entrypoint for it.
-            if variant.is_debug() && *env == Environment::Slim {
-                continue;
-            }
             let content = targets::generate_esm_entrypoint(*env, &wasm_name, *variant);
             let path = out_dir.join(targets::paths::esm_entrypoint(*env, *variant));
             std::fs::write(&path, content)?;
@@ -38,9 +33,6 @@ pub fn generate(out_dir: &Path, crate_name: &str) -> Result<()> {
 
         println!("  Generating CJS entrypoints ({})...", variant,);
         for env in Environment::all() {
-            if variant.is_debug() && *env == Environment::Slim {
-                continue;
-            }
             if let Some(content) = targets::generate_cjs_entrypoint(*env, &wasm_name, *variant) {
                 let path = out_dir.join(targets::paths::cjs_entrypoint(*env, *variant));
                 std::fs::write(&path, content)?;

--- a/src/build/package_json.rs
+++ b/src/build/package_json.rs
@@ -157,13 +157,23 @@ fn build_exports_map(dist: &str, package_name: &str, has_debug: bool) -> Value {
         json!(p(&targets::paths::iife_bundle(WasmVariant::Optimized))),
     );
 
-    // Debug variant exports: mirror ./, ./wasm, ./wasm-base64, ./iife.
-    // No ./debug/slim -- manual init makes the "skip auto-init" point moot
-    // and the debug variant already ships the unoptimized wasm.
+    // Debug variant exports mirror the optimized side: ./, ./slim, ./wasm,
+    // ./wasm-base64, ./iife. ./debug/slim exists because the debug wasm has
+    // different imports than the optimized wasm (e.g. __wbindgen_throw is
+    // optimized away in release), so the JS bindings paired with each variant
+    // are not interchangeable.
     if has_debug {
         exports.insert(
             "./debug".to_string(),
             build_conditional_export(dist, WasmVariant::Debug),
+        );
+        exports.insert(
+            "./debug/slim".to_string(),
+            json!({
+                "types": p(&targets::paths::types()),
+                "import": p(&targets::paths::esm_entrypoint(Environment::Slim, WasmVariant::Debug)),
+                "require": p(&targets::paths::cjs_entrypoint(Environment::Slim, WasmVariant::Debug))
+            }),
         );
         exports.insert(
             "./debug/wasm".to_string(),

--- a/tests/fixtures/test-crate/Cargo.toml
+++ b/tests/fixtures/test-crate/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "=0.2.108"
+wasm-bindgen = "=0.2.120"
 
 [profile.release]
 debug = true

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -613,6 +613,11 @@ fn test_vite_build_slim() {
 }
 
 #[test]
+fn test_vite_build_slim_debug() {
+    run_test("vite_build_slim_debug").unwrap();
+}
+
+#[test]
 fn test_workerd_fullfat() {
     run_test("workerd_fullfat").unwrap();
 }
@@ -725,6 +730,36 @@ fn test_debug_symbols() {
 #[test]
 fn test_node_esm_debug() {
     run_test("node_esm_debug").unwrap();
+}
+
+#[test]
+fn test_node_esm_slim_debug() {
+    run_test("node_esm_slim_debug").unwrap();
+}
+
+#[test]
+fn test_node_cjs_slim_debug() {
+    run_test("node_cjs_slim_debug").unwrap();
+}
+
+#[test]
+fn test_webpack_esm_slim_debug() {
+    run_test("webpack_esm_slim_debug").unwrap();
+}
+
+#[test]
+fn test_webpack_cjs_slim_debug() {
+    run_test("webpack_cjs_slim_debug").unwrap();
+}
+
+#[test]
+fn test_vite_dev_slim_debug() {
+    run_test("vite_dev_slim_debug").unwrap();
+}
+
+#[test]
+fn test_workerd_slim_debug() {
+    run_test("workerd_slim_debug").unwrap();
 }
 
 /// Test that building with a scoped npm package name (e.g. @scope/name) works.

--- a/tests/templates/node_cjs_slim_debug/package.json
+++ b/tests/templates/node_cjs_slim_debug/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "node-cjs-slim-debug-test",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "build": "true",
+    "test": "node test.cjs"
+  }
+}

--- a/tests/templates/node_cjs_slim_debug/test.cjs
+++ b/tests/templates/node_cjs_slim_debug/test.cjs
@@ -1,0 +1,20 @@
+const { add, greet, initSync } = require('test-wasm-lib/debug/slim');
+const fs = require('fs');
+
+// Initialize wasm manually using the package's debug wasm export
+const wasmPath = require.resolve('test-wasm-lib/debug/wasm');
+const wasmBytes = fs.readFileSync(wasmPath);
+initSync({ module: wasmBytes });
+
+// Run tests
+const result1 = add(2, 3);
+if (result1 !== 5) {
+  throw new Error(`add(2, 3) expected 5, got ${result1}`);
+}
+
+const result2 = greet('World');
+if (result2 !== 'Hello, World!') {
+  throw new Error(`greet("World") expected "Hello, World!", got ${result2}`);
+}
+
+console.log('WASM_BODGE_TEST_PASSED');

--- a/tests/templates/node_esm_slim_debug/package.json
+++ b/tests/templates/node_esm_slim_debug/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "node-esm-slim-debug-test",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "true",
+    "test": "node test.mjs"
+  }
+}

--- a/tests/templates/node_esm_slim_debug/test.mjs
+++ b/tests/templates/node_esm_slim_debug/test.mjs
@@ -1,0 +1,21 @@
+import { add, greet, initSync } from 'test-wasm-lib/debug/slim';
+import { createRequire } from 'node:module';
+
+// Initialize wasm manually using the package's debug wasm export
+const require = createRequire(import.meta.url);
+const wasmPath = require.resolve('test-wasm-lib/debug/wasm');
+const wasmBytes = require('node:fs').readFileSync(wasmPath);
+initSync({ module: wasmBytes });
+
+// Run tests
+const result1 = add(2, 3);
+if (result1 !== 5) {
+  throw new Error(`add(2, 3) expected 5, got ${result1}`);
+}
+
+const result2 = greet('World');
+if (result2 !== 'Hello, World!') {
+  throw new Error(`greet("World") expected "Hello, World!", got ${result2}`);
+}
+
+console.log('WASM_BODGE_TEST_PASSED');

--- a/tests/templates/vite_build_slim_debug/index.html
+++ b/tests/templates/vite_build_slim_debug/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <div id="result"></div>
+  <script type="module" src="/main.js"></script>
+</body>
+</html>

--- a/tests/templates/vite_build_slim_debug/main.js
+++ b/tests/templates/vite_build_slim_debug/main.js
@@ -1,0 +1,19 @@
+import { add, greet, initSync } from 'test-wasm-lib/debug/slim';
+import wasmUrl from 'test-wasm-lib/debug/wasm?url';
+
+try {
+  // Fetch and initialize wasm
+  const response = await fetch(wasmUrl);
+  const bytes = await response.arrayBuffer();
+  initSync({ module: new Uint8Array(bytes) });
+
+  const result1 = add(2, 3);
+  const result2 = greet('World');
+
+  document.getElementById('result').textContent =
+    result1 === 5 && result2 === 'Hello, World!'
+      ? 'WASM_BODGE_TEST_PASSED'
+      : 'FAILED: ' + result1 + ', ' + result2;
+} catch (e) {
+  document.getElementById('result').textContent = 'ERROR: ' + e.message;
+}

--- a/tests/templates/vite_build_slim_debug/package.json
+++ b/tests/templates/vite_build_slim_debug/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vite-build-slim-test",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "test": "true"
+  },
+  "devDependencies": {
+    "vite": "^7.0.0",
+    "vite-plugin-wasm": "^3.0.0",
+    "vite-plugin-top-level-await": "^1.0.0"
+  }
+}

--- a/tests/templates/vite_build_slim_debug/vite.config.js
+++ b/tests/templates/vite_build_slim_debug/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import wasm from 'vite-plugin-wasm';
+import topLevelAwait from 'vite-plugin-top-level-await';
+
+export default defineConfig({
+  plugins: [wasm(), topLevelAwait()],
+  build: { target: 'esnext' },
+  optimizeDeps: { exclude: ['test-wasm-lib'] },
+});

--- a/tests/templates/vite_dev_slim_debug/index.html
+++ b/tests/templates/vite_dev_slim_debug/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <div id="result"></div>
+  <script type="module" src="/main.js"></script>
+</body>
+</html>

--- a/tests/templates/vite_dev_slim_debug/main.js
+++ b/tests/templates/vite_dev_slim_debug/main.js
@@ -1,0 +1,19 @@
+import { add, greet, initSync } from 'test-wasm-lib/debug/slim';
+import wasmUrl from 'test-wasm-lib/debug/wasm?url';
+
+try {
+  // Fetch and initialize wasm
+  const response = await fetch(wasmUrl);
+  const bytes = await response.arrayBuffer();
+  initSync({ module: new Uint8Array(bytes) });
+
+  const result1 = add(2, 3);
+  const result2 = greet('World');
+
+  document.getElementById('result').textContent =
+    result1 === 5 && result2 === 'Hello, World!'
+      ? 'WASM_BODGE_TEST_PASSED'
+      : 'FAILED: ' + result1 + ', ' + result2;
+} catch (e) {
+  document.getElementById('result').textContent = 'ERROR: ' + e.message;
+}

--- a/tests/templates/vite_dev_slim_debug/package.json
+++ b/tests/templates/vite_dev_slim_debug/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "vite-dev-slim-debug-test",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "true"
+  },
+  "devDependencies": {
+    "vite": "^7.0.0",
+    "vite-plugin-wasm": "^3.0.0",
+    "vite-plugin-top-level-await": "^1.0.0"
+  }
+}

--- a/tests/templates/vite_dev_slim_debug/vite.config.js
+++ b/tests/templates/vite_dev_slim_debug/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import wasm from 'vite-plugin-wasm';
+import topLevelAwait from 'vite-plugin-top-level-await';
+
+export default defineConfig({
+  plugins: [wasm(), topLevelAwait()],
+  build: { target: 'esnext' },
+  optimizeDeps: { exclude: ['test-wasm-lib'] },
+});

--- a/tests/templates/webpack_cjs_slim_debug/index.html
+++ b/tests/templates/webpack_cjs_slim_debug/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Webpack CJS Slim Debug Test</title>
+</head>
+<body>
+  <div id="result">Loading...</div>
+  <script src="bundle.js"></script>
+</body>
+</html>

--- a/tests/templates/webpack_cjs_slim_debug/main.js
+++ b/tests/templates/webpack_cjs_slim_debug/main.js
@@ -1,0 +1,19 @@
+import { add, greet, default as init } from 'test-wasm-lib/debug/slim';
+
+async function run() {
+  try {
+    await init();
+    const result1 = add(2, 3);
+    const result2 = greet('World');
+
+    if (result1 === 5 && result2 === 'Hello, World!') {
+      document.getElementById('result').textContent = 'WASM_BODGE_TEST_PASSED';
+    } else {
+      document.getElementById('result').textContent = 'FAILED: ' + result1 + ', ' + result2;
+    }
+  } catch (e) {
+    document.getElementById('result').textContent = 'ERROR: ' + e.message;
+  }
+}
+
+run();

--- a/tests/templates/webpack_cjs_slim_debug/package.json
+++ b/tests/templates/webpack_cjs_slim_debug/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "webpack-cjs-slim-debug-test",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "webpack --mode production"
+  },
+  "devDependencies": {
+    "copy-webpack-plugin": "^12.0.0",
+    "webpack": "^5.0.0",
+    "webpack-cli": "^5.0.0"
+  }
+}

--- a/tests/templates/webpack_cjs_slim_debug/webpack.config.cjs
+++ b/tests/templates/webpack_cjs_slim_debug/webpack.config.cjs
@@ -1,0 +1,19 @@
+const path = require('path');
+const CopyPlugin = require('copy-webpack-plugin');
+
+module.exports = {
+  entry: './main.js',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+  experiments: {
+    asyncWebAssembly: true,
+  },
+  plugins: [
+    new CopyPlugin({
+      patterns: [{ from: 'index.html', to: 'index.html' }],
+    }),
+  ],
+  mode: 'production',
+};

--- a/tests/templates/webpack_esm_slim_debug/index.html
+++ b/tests/templates/webpack_esm_slim_debug/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Webpack ESM Slim Debug Test</title>
+</head>
+<body>
+  <div id="result">Loading...</div>
+  <script src="bundle.js"></script>
+</body>
+</html>

--- a/tests/templates/webpack_esm_slim_debug/main.js
+++ b/tests/templates/webpack_esm_slim_debug/main.js
@@ -1,0 +1,19 @@
+import { add, greet, default as init } from 'test-wasm-lib/debug/slim';
+
+async function run() {
+  try {
+    await init();
+    const result1 = add(2, 3);
+    const result2 = greet('World');
+
+    if (result1 === 5 && result2 === 'Hello, World!') {
+      document.getElementById('result').textContent = 'WASM_BODGE_TEST_PASSED';
+    } else {
+      document.getElementById('result').textContent = 'FAILED: ' + result1 + ', ' + result2;
+    }
+  } catch (e) {
+    document.getElementById('result').textContent = 'ERROR: ' + e.message;
+  }
+}
+
+run();

--- a/tests/templates/webpack_esm_slim_debug/package.json
+++ b/tests/templates/webpack_esm_slim_debug/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "webpack-esm-slim-debug-test",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "webpack --mode production"
+  },
+  "devDependencies": {
+    "copy-webpack-plugin": "^12.0.0",
+    "webpack": "^5.0.0",
+    "webpack-cli": "^5.0.0"
+  }
+}

--- a/tests/templates/webpack_esm_slim_debug/webpack.config.cjs
+++ b/tests/templates/webpack_esm_slim_debug/webpack.config.cjs
@@ -1,0 +1,19 @@
+const path = require('path');
+const CopyPlugin = require('copy-webpack-plugin');
+
+module.exports = {
+  entry: './main.js',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+  experiments: {
+    asyncWebAssembly: true,
+  },
+  plugins: [
+    new CopyPlugin({
+      patterns: [{ from: 'index.html', to: 'index.html' }],
+    }),
+  ],
+  mode: 'production',
+};

--- a/tests/templates/workerd_slim_debug/package.json
+++ b/tests/templates/workerd_slim_debug/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "workerd-slim-debug-test",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "wrangler deploy --dry-run --outdir dist",
+    "test": "true"
+  }
+}

--- a/tests/templates/workerd_slim_debug/worker.js
+++ b/tests/templates/workerd_slim_debug/worker.js
@@ -1,0 +1,19 @@
+import { add, greet, initSync } from 'test-wasm-lib/debug/slim';
+import { wasmBase64 } from 'test-wasm-lib/debug/wasm-base64';
+
+// Initialize wasm from base64
+const bytes = Uint8Array.from(atob(wasmBase64), (c) => c.charCodeAt(0));
+initSync({ module: bytes });
+
+export default {
+  async fetch(request) {
+    const result1 = add(2, 3);
+    const result2 = greet('World');
+
+    if (result1 === 5 && result2 === 'Hello, World!') {
+      return new Response('WASM_BODGE_TEST_PASSED');
+    } else {
+      return new Response('FAILED: ' + result1 + ', ' + result2, { status: 500 });
+    }
+  },
+};

--- a/tests/templates/workerd_slim_debug/wrangler.toml
+++ b/tests/templates/workerd_slim_debug/wrangler.toml
@@ -1,0 +1,3 @@
+name = "test-worker"
+main = "worker.js"
+compatibility_date = "2024-01-01"


### PR DESCRIPTION
Problem: In ab5b6c2e when we added the ability to ship a debug variant of the webassembly blob we assumed that the JavaScript wrapper wasm-bindgen generates for the debug vs release versions of the WebAssembly would be the same and so we did not add a separate `/debug/slim` endpoint. Unfortunately it turns out that the wrapper is _not_ the same because the generated webassembly has different exports. This means that attempting to initialize the slim endpoint with a debug webassembly blob throws exceptions when trying to initialize the webassembly module.

Solution: ship the JS wrapper as a `/debug/slim` endpoint which must be initialized with the /debug webassembly.